### PR TITLE
minor change in second example

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -63,7 +63,7 @@
 <div class="for_info_only">
     <strong>Example:</strong>
 <textarea data-code="python">texas_referee("Kh,Qh,Ah,9s,2c,Th,Jh") == "Ah,Kh,Qh,Jh,Th"
-texas_referee("Qd,Ad,9d,8d,Td,Jd,7d") == "Qd,Jd,Td,9d,8d",</textarea>
+texas_referee("Qd,Ac,9d,8d,Td,Jd,7d") == "Qd,Jd,Td,9d,8d",</textarea>
 </div>
 
 <p class="for_info_only">


### PR DESCRIPTION
example would be wrong else:  
(original) texas_referee("Qd,Ad,9d,8d,Td,Jd,7d")  equals "Ad,Qd,Jd,Td,9d", not the given value.